### PR TITLE
Add Linux runtime support for Prisma

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- configure Prisma client to support `linux-musl-openssl-3.0.x`

## Testing
- `npm test` *(fails: no test specified)*
- `npx prisma generate` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687cd1a9d5bc8320bb09c697370628d7